### PR TITLE
Add better 3rd party tooltip support with tooltipDataAttrs

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -43,6 +43,7 @@ function customOnClick(value) {
   }
 }
 
+const customTooltipDataAttrs = { 'data-toggle': 'tooltip' };
 const randomValues = generateRandomValues(200);
 const halfYearAgo = shiftDate(new Date(), -180);
 const pastRandomValues = generateRandomValues(200, halfYearAgo);
@@ -80,6 +81,7 @@ class Demo extends React.Component {
               values={randomValues}
               classForValue={customClassForValue}
               titleForValue={customTitleForValue}
+              tooltipDataAttrs={customTooltipDataAttrs}
               onClick={customOnClick}
             />
           </div>
@@ -150,7 +152,7 @@ class Demo extends React.Component {
 
         <DemoItem
           name="horizontal"
-          description="Whether to orient horizontally or vertically. Can be used in combination with numDays/endDate to show just the current month"
+          description="Whether to orient horizontally or vertically. Can be used in combination with numDays/endDate to show just the current month."
         >
           <div className="row">
             <div className="col-xs-4">
@@ -192,12 +194,13 @@ class Demo extends React.Component {
         </DemoItem>
 
         <DemoItem
-          name="titleForValue"
-          description="Callback for determining hover tooltip of each value"
+          name="titleForValue, tooltipDataAttrs"
+          description="These props configure each value's title and data attributes, for generating 3rd party hover tooltips (this demo uses bootstrap tooltips)"
         >
           <CalendarHeatmap
             values={randomValues}
             titleForValue={customTitleForValue}
+            tooltipDataAttrs={customTooltipDataAttrs}
           />
         </DemoItem>
 

--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -34,12 +34,12 @@ function customClassForValue(value) {
 }
 
 function customTitleForValue(value) {
-  return value ? `You're hovering over ${value.date} with value ${value.count}` : null;
+  return value ? `You're hovering over ${value.date.toDateString()} with value ${value.count}` : null;
 }
 
 function customOnClick(value) {
   if (value) {
-    alert(`Clicked on ${value.date} with value ${value.count}`);
+    alert(`Clicked on ${value.date.toDateString()} with value ${value.count}`);
   }
 }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,5 +31,15 @@
   <body>
     <div id="demo"></div>
     <script src="index.js" type="text/javascript"></script>
+
+    <!-- bootstrap tooltips -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.3.2/js/tether.min.js"></script>
+    <script src="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/js/bootstrap.js"></script>
+    <script>
+      $(document).ready(function() {
+        $('[data-toggle="tooltip"]').tooltip();
+      });
+    </script>
   </body>
 </html>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -184,10 +184,10 @@ class CalendarHeatmap extends React.Component {
         height={SQUARE_SIZE}
         x={x}
         y={y}
-        data-toggle="tooltip"
         title={this.getTitleForIndex(index)}
         className={this.getClassNameForIndex(index)}
         onClick={this.handleClick.bind(this, this.getValueForIndex(index))}
+        {...this.props.tooltipDataAttrs}
       >
       </rect>
     );
@@ -254,6 +254,7 @@ CalendarHeatmap.propTypes = {
   horizontal: PropTypes.bool,            // whether to orient horizontally or vertically
   showMonthLabels: PropTypes.bool,       // whether to show month labels
   showOutOfRangeDays: PropTypes.bool,    // whether to render squares for extra days in week after endDate, and before start date
+  tooltipDataAttrs: PropTypes.object,    // data attributes to add to square for setting 3rd party tooltips, e.g. { 'data-toggle': 'tooltip' } for bootstrap tooltips
   titleForValue: PropTypes.func,         // function which returns title text for value
   classForValue: PropTypes.func,         // function which returns html class for value
   onClick: PropTypes.func,               // callback function when a square is clicked
@@ -266,7 +267,6 @@ CalendarHeatmap.defaultProps = {
   horizontal: true,
   showMonthLabels: true,
   showOutOfRangeDays: false,
-  titleForValue: null,
   classForValue: (value) => {
     return value ? 'color-filled' : 'color-empty';
   },

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -184,10 +184,11 @@ class CalendarHeatmap extends React.Component {
         height={SQUARE_SIZE}
         x={x}
         y={y}
+        data-toggle="tooltip"
+        title={this.getTitleForIndex(index)}
         className={this.getClassNameForIndex(index)}
         onClick={this.handleClick.bind(this, this.getValueForIndex(index))}
       >
-        <title>{this.getTitleForIndex(index)}</title>
       </rect>
     );
   }


### PR DESCRIPTION
titleForValue now sets the title attribute on the rect, instead of a child <title> svg component.

This allows usage with 3rd party tooltip libraries like bootstrap tooltip - see sample configuration in the demo.