### PR TITLE
Allow tooltipDataAttrs to be a function

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -207,7 +207,7 @@ class Demo extends React.Component {
 
         <DemoItem
           name="tooltipDataAttrs"
-          example="{ 'data-toggle': 'tooltip' }"
+          example="{ 'data-toggle': 'tooltip' } or (value) => ({ 'data-tooltip': `Tooltip: ${value}` })"
           description="Sets data attributes for all squares, for generating 3rd party hover tooltips (this demo uses bootstrap tooltips)."
         >
         </DemoItem>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -87,6 +87,7 @@ class CalendarHeatmap extends React.Component {
         value: value,
         className: this.props.classForValue(value),
         title: this.props.titleForValue ? this.props.titleForValue(value) : null,
+        tooltipDataAttrs: this.getTooltipDataAttrsForValue(value),
       };
       return memo;
     }, {});
@@ -113,6 +114,24 @@ class CalendarHeatmap extends React.Component {
       return this.state.valueCache[index].title;
     } else {
       return this.props.titleForValue ? this.props.titleForValue(null) : null;
+    }
+  }
+
+  getTooltipDataAttrsForIndex(index) {
+    if (this.state.valueCache[index]) {
+      return this.state.valueCache[index].tooltipDataAttrs;
+    } else {
+      return this.getTooltipDataAttrsForValue(null);
+    }
+  }
+
+  getTooltipDataAttrsForValue(value) {
+    const { tooltipDataAttrs } = this.props;
+
+    if (typeof tooltipDataAttrs === "function") {
+      return tooltipDataAttrs(value);
+    } else {
+      return tooltipDataAttrs;
     }
   }
 
@@ -187,7 +206,7 @@ class CalendarHeatmap extends React.Component {
         title={this.getTitleForIndex(index)}
         className={this.getClassNameForIndex(index)}
         onClick={this.handleClick.bind(this, this.getValueForIndex(index))}
-        {...this.props.tooltipDataAttrs}
+        {...this.getTooltipDataAttrsForIndex(index)}
       >
       </rect>
     );
@@ -254,7 +273,7 @@ CalendarHeatmap.propTypes = {
   horizontal: PropTypes.bool,            // whether to orient horizontally or vertically
   showMonthLabels: PropTypes.bool,       // whether to show month labels
   showOutOfRangeDays: PropTypes.bool,    // whether to render squares for extra days in week after endDate, and before start date
-  tooltipDataAttrs: PropTypes.object,    // data attributes to add to square for setting 3rd party tooltips, e.g. { 'data-toggle': 'tooltip' } for bootstrap tooltips
+  tooltipDataAttrs: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),    // data attributes to add to square for setting 3rd party tooltips, e.g. { 'data-toggle': 'tooltip' } for bootstrap tooltips
   titleForValue: PropTypes.func,         // function which returns title text for value
   classForValue: PropTypes.func,         // function which returns html class for value
   onClick: PropTypes.func,               // callback function when a square is clicked

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -121,7 +121,7 @@ class CalendarHeatmap extends React.Component {
     if (this.state.valueCache[index]) {
       return this.state.valueCache[index].tooltipDataAttrs;
     } else {
-      return this.getTooltipDataAttrsForValue(null);
+      return this.getTooltipDataAttrsForValue({ date: null, count: null });
     }
   }
 

--- a/test/components/CalendarHeatmap.spec.js
+++ b/test/components/CalendarHeatmap.spec.js
@@ -141,12 +141,12 @@ describe('CalendarHeatmap props', () => {
           endDate={today}
           numDays={numDays}
           tooltipDataAttrs={({ count }) => ({
-            'data-tooltip': `Count: ${count}`
+            'data-tooltip': `Count: ${count}`,
           })}
         />
       );
 
-      assert(wrapper.find("[data-tooltip=\"Count: 1\"]").length === 1);
-    })
-  })
+      assert(wrapper.find('[data-tooltip="Count: 1"]').length === 1);
+    });
+  });
 });

--- a/test/components/CalendarHeatmap.spec.js
+++ b/test/components/CalendarHeatmap.spec.js
@@ -126,4 +126,27 @@ describe('CalendarHeatmap props', () => {
     );
     assert.equal(0, hidden.find('text').length);
   });
+
+  describe('tooltipDataAttrs', () => {
+    it('allows a function to be passed', () => {
+      const today = new Date();
+      const numDays = 10;
+      const expectedStartDate = shiftDate(today, -numDays + 1);
+      const wrapper = shallow(
+        <CalendarHeatmap
+          values={[
+            { date: today, count: 1 },
+            { date: expectedStartDate, count: 0 },
+          ]}
+          endDate={today}
+          numDays={numDays}
+          tooltipDataAttrs={({ count }) => ({
+            'data-tooltip': `Count: ${count}`
+          })}
+        />
+      );
+
+      assert(wrapper.find("[data-tooltip=\"Count: 1\"]").length === 1);
+    })
+  })
 });


### PR DESCRIPTION
I needed a little more control over the `tooltipDataAttrs` prop so that I could use ReactTooltip together with this awesome package. I decided that it made sense to give users the ability to pass a function to `tooltipDataAttrs` which in turn would receive the value as an argument.