### PR TITLE
Add transformDayElement prop to improve flexibility

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -217,6 +217,13 @@ class Demo extends React.Component {
         >
         </DemoItem>
 
+        <DemoItem
+          name="transformDayElement"
+          example="(element, value, index) => React.cloneElement(element, {title: `${value.date}, ${index}`)"
+          description="A function to further transform generated svg element for a single day, can be used to attach event handlers, add tooltips and more"
+        >
+        </DemoItem>
+
         <hr />
         <div className="text-xs-center m-y-3">
           <a className="btn btn-info btn-lg" href={githubURL}>View project on Github</a>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -184,7 +184,8 @@ class CalendarHeatmap extends React.Component {
       return null;
     }
     const [x, y] = this.getSquareCoordinates(dayIndex);
-    return (
+    const value = this.getValueForIndex(index);
+    const rect = (
       <rect
         key={index}
         width={SQUARE_SIZE}
@@ -193,10 +194,12 @@ class CalendarHeatmap extends React.Component {
         y={y}
         title={this.getTitleForIndex(index)}
         className={this.getClassNameForIndex(index)}
-        onClick={this.handleClick.bind(this, this.getValueForIndex(index))}
+        onClick={this.handleClick.bind(this, value)}
         {...this.getTooltipDataAttrsForIndex(index)}
       />
     );
+    const transformDayElement = this.props.transformDayElement;
+    return transformDayElement ? transformDayElement(rect, value, index) : rect;
   }
 
   renderWeek(weekIndex) {
@@ -264,6 +267,7 @@ CalendarHeatmap.propTypes = {
   titleForValue: PropTypes.func,         // function which returns title text for value
   classForValue: PropTypes.func,         // function which returns html class for value
   onClick: PropTypes.func,               // callback function when a square is clicked
+  transformDayElement: PropTypes.func    // function to further transform the svg element for a single day
 };
 
 CalendarHeatmap.defaultProps = {

--- a/test/components/CalendarHeatmap.spec.jsx
+++ b/test/components/CalendarHeatmap.spec.jsx
@@ -129,7 +129,7 @@ describe('CalendarHeatmap props', () => {
 
   it('transformDayElement', () => {
     const transform = (rect, value, index) => {
-      return React.cloneElement(rect, {'data-test': index});
+      return React.cloneElement(rect, {'data-test': 'ok'});
     };
     const today = new Date();
     const expectedStartDate = shiftDate(today, -1);
@@ -145,7 +145,7 @@ describe('CalendarHeatmap props', () => {
       />
     );
 
-    assert(wrapper.find('[data-test=0]').length === 1);
+    assert(wrapper.find('[data-test="ok"]').length === 1);
   });
 
   describe('tooltipDataAttrs', () => {

--- a/test/components/CalendarHeatmap.spec.jsx
+++ b/test/components/CalendarHeatmap.spec.jsx
@@ -127,6 +127,27 @@ describe('CalendarHeatmap props', () => {
     assert.equal(0, hidden.find('text').length);
   });
 
+  it('transformDayElement', () => {
+    const transform = (rect, value, index) => {
+      return React.cloneElement(rect, {'data-test': index});
+    };
+    const today = new Date();
+    const expectedStartDate = shiftDate(today, -1);
+    const wrapper = shallow(
+      <CalendarHeatmap
+        values={[
+          { date: today },
+          { date: expectedStartDate },
+        ]}
+        endDate={today}
+        numDays={1}
+        transformDayElement={transform}
+      />
+    );
+
+    assert(wrapper.find('[data-test=0]').length === 1);
+  });
+
   describe('tooltipDataAttrs', () => {
     it('allows a function to be passed', () => {
       const today = new Date();


### PR DESCRIPTION
In this pull request I tried to add a `transformDayElement` function prop to improve the entire flexibility of react-calendar-heatmap, this function is called after the `<rect>` element is generated and passed `rect, value, index` as arguments, this function must return a `<rect>` element (because we can only place svg elements inside `<g>`)

By add this prop we can archive many customizations in a more react style way

### Add tooltips

In react ecosystem there are bunches of tooltip component, a lot of them are implemented by accepting a `children` prop and add event listeners on them, we can utilize these components in this function:

```
const transformDayElement = (element, value) => (
  <Tooltip title={`${value.date}: ${value.count}`}>
    {element}
  </Tooltip>
);
```

### Customize colors

Also we can add custom colors inline:

```
const transformDayElement = (element, value) => {
  const color = `rgba(0, 255, 0, ${value % 100}%`;
  return React.cloneElement(element, {style: {fill: color}});
};
```

### Add more events

Add event is as simple as providing a callback prop:

```
const transformDayElement = (element, value) => {
  return React.cloneElement(element, {onMouseEnter: ...});
};
```

---

Actually we can archive anything that `onClick`, `titleForValue`, `tooltipDataAttr` and `classForValue` props try to archive by simply providing the `transformDayElement` prop, and we don't need to struggle with non-react style tooltip implements