### PR TITLE
Add customizable month label text

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -92,6 +92,7 @@ class Demo extends React.Component {
               titleForValue={customTitleForValue}
               tooltipDataAttrs={customTooltipDataAttrs}
               onClick={customOnClick}
+              monthLabels={['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']}
             />
           </div>
         </div>
@@ -214,6 +215,13 @@ class Demo extends React.Component {
           name="classForValue"
           example="(value) => (value.count > 0 ? 'blue' : 'white')"
           description="Callback for determining CSS class to apply to each value."
+        >
+        </DemoItem>
+
+        <DemoItem
+          name="monthLabels"
+          example="['01', '02', ..., '12']"
+          description="An array with 12 strings representing the text from janurary to december"
         >
         </DemoItem>
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,17 +2,4 @@ export const MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
 
 export const DAYS_IN_WEEK = 7;
 
-export const MONTH_LABELS = {
-  0: 'Jan',
-  1: 'Feb',
-  2: 'Mar',
-  3: 'Apr',
-  4: 'May',
-  5: 'Jun',
-  6: 'Jul',
-  7: 'Aug',
-  8: 'Sep',
-  9: 'Oct',
-  10: 'Nov',
-  11: 'Dec',
-};
+export const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -228,7 +228,7 @@ class CalendarHeatmap extends React.Component {
           x={x}
           y={y}
         >
-          {MONTH_LABELS[endOfWeek.getMonth()]}
+          {this.props.monthLabels[endOfWeek.getMonth()]}
         </text>
       ) : null;
     });
@@ -266,6 +266,7 @@ CalendarHeatmap.propTypes = {
   tooltipDataAttrs: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),    // data attributes to add to square for setting 3rd party tooltips, e.g. { 'data-toggle': 'tooltip' } for bootstrap tooltips
   titleForValue: PropTypes.func,         // function which returns title text for value
   classForValue: PropTypes.func,         // function which returns html class for value
+  monthLabels: PropTypes.arrayOf(PropTypes.string), // An array with 12 strings representing the text from janurary to december
   onClick: PropTypes.func,               // callback function when a square is clicked
   transformDayElement: PropTypes.func    // function to further transform the svg element for a single day
 };
@@ -277,6 +278,7 @@ CalendarHeatmap.defaultProps = {
   horizontal: true,
   showMonthLabels: true,
   showOutOfRangeDays: false,
+  monthLabels: MONTH_LABELS,
   classForValue: value => (value ? 'color-filled' : 'color-empty'),
 };
 


### PR DESCRIPTION
Fix #30

I also changed the `MONTH_LABELS` constant from object to array, it seems an object with keys from 0 to 11 doesn't give more functionality than array