### PR TITLE
Set environment variable in an OS agnostic way (fixes issue #58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "svg"
   ],
   "scripts": {
-    "build": "NODE_ENV=production webpack",
-    "build:demo": "NODE_ENV=demo webpack",
+    "build": "cross-env NODE_ENV=production webpack",
+    "build:demo": "cross-env NODE_ENV=demo webpack",
     "deploy:demo": "npm run build:demo && ./scripts/build_ghpages.sh",
     "clean": "rimraf build",
     "lint": "eslint --ext .js,.jsx --cache . && echo \"eslint: no lint errors found\" || true",
@@ -39,6 +39,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.3.13",
     "babel-register": "^6.8.0",
+    "cross-env": "^5.1.1",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.2",
     "eslint": "^4.9.0",


### PR DESCRIPTION
Set environment variables in a way that works on OS X, Linux, and Windows; instead of only on OS X and Linux.

This fixes issue #58.