### PR TITLE
Fix the problem that startDate and endDate may not be converted.

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -33,7 +33,7 @@ class CalendarHeatmap extends React.Component {
       console.warn('numDays is a deprecated prop. It will be removed in the next release. Consider using the startDate prop instead.');
       return numDays;
     }
-    const timeDiff = endDate - startDate;
+    const timeDiff = this.getEndDate() - convertToDate(startDate);
     return Math.ceil(timeDiff / MILLISECONDS_IN_ONE_DAY);
   }
 

--- a/test/CalendarHeatmap.test.jsx
+++ b/test/CalendarHeatmap.test.jsx
@@ -36,6 +36,16 @@ describe('CalendarHeatmap', () => {
     expect(wrapper.find('.color-filled').length).toBe(2);
   });
 
+  it('should handle string formatted date range', () => {
+    const wrapper = shallow(<CalendarHeatmap
+      endDate='2017-12-31'
+      startDate='2017-01-01'
+      values={values}
+    />);
+
+    expect(wrapper.find('.color-filled').length).toBe(2);
+  });
+
   it('shows values within an updated date range', () => {
     const wrapper = shallow(<CalendarHeatmap
       endDate={new Date('2017-12-31')}


### PR DESCRIPTION
I found sometimes 'endDate' and 'startDate' are not converted even though the component should also handle the string formatted date.
I fixed this problem and added a test case to confirm the problem was resolved.