### PR TITLE
Fix that tooltip doesn't work on demo page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,10 +27,14 @@
     <!-- bootstrap tooltips -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/tether/1.3.2/js/tether.min.js"></script>
-    <script src="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/js/bootstrap.js"></script>
+    <script src="https://cdn.rawgit.com/twbs/bootstrap/v4-dev/dist/js/bootstrap.bundle.min.js"></script>
     <script>
       $(document).ready(function() {
-        $('[data-toggle="tooltip"]').tooltip();
+        $('[data-toggle="tooltip"]').tooltip({
+          title: function() {
+            return $(this)[0].textContent;
+          }
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
- Fix to use bootstrap.bundle.min.js because Popper.js is necessary to use bootstrap's tooltip.
https://getbootstrap.com/docs/4.0/components/tooltips/#overview
- Fix that tooltip is not able to get the value of title.