### PR TITLE
Add date label option

### DIFF
--- a/demo/demo.jsx
+++ b/demo/demo.jsx
@@ -138,6 +138,12 @@ class Demo extends React.Component {
         />
 
         <DemoItem
+          name="showDateLabels"
+          example="true"
+          description="Toggle for removing date labels."
+        />
+
+        <DemoItem
           name="showOutOfRangeDays"
           example="false"
           description="Toggle display of extra days in week that are past endDate and before beginning of range."
@@ -189,6 +195,12 @@ class Demo extends React.Component {
           name="classForValue"
           example="(value) => (value.count > 0 ? 'blue' : 'white')"
           description="Callback for determining CSS class to apply to each value."
+        />
+
+        <DemoItem
+          name="dateLabelForValue"
+          example="(value) => (value ? (new Date(value.date)).getDate() : '')"
+          description="Callback for determining date label to apply to each value."
         />
 
         <DemoItem


### PR DESCRIPTION
I want to display numbers in the square of the contribution graph, so I add the options.
For example, you can display the date in the square of the contribution graph and make it look like a calendar.

![contribution_monthly](https://user-images.githubusercontent.com/4343096/43577395-b1b62868-9686-11e8-87ad-53967c1e316a.png)

I add two options.
showDateLabels determines whether to display date labels.
dateLabelForValue is a callback function to determine what to display.