### PR TITLE
More tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,7 +10,8 @@
     "test": {
       "presets": [
         ["env", { "modules": "commonjs" }]
-      ]
+      ],
+      "plugins": ["transform-object-rest-spread"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "babel-jest": "^23.4.2",
     "babel-loader": "^7.1.5",
     "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.0.0",
     "babel-register": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint src",
     "prepublish": "npm run clean && npm run build",
     "test": "jest --config jest.config.js --coverage",
+    "test:watch": "jest --config jest.config.js --watch",
     "start": "npm-run-all --parallel start:js start:css",
     "start:css": "postcss src/styles.css --use autoprefixer -d dist/ --no-map --watch",
     "start:js": "cross-env NODE_ENV=development rollup -c -w"

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -242,19 +242,47 @@ describe('CalendarHeatmap props', () => {
   });
 
   describe('event handlers', () => {
-    it('calls props.onClick', () => {
-      const count = 999;
-      const startDate = '2018-06-01';
-      const endDate = '2018-06-03';
-      const values = [ { date: '2018-06-02', count } ];
+    const count = 999;
+    const startDate = '2018-06-01';
+    const endDate = '2018-06-03';
+    const values = [ { date: '2018-06-02', count } ];
+    const props = {
+      values,
+      startDate,
+      endDate,
+    };
+    const expectedValue = values[0];
+
+    it('calls props.onClick with the correct value', () => {
       const onClick = jest.fn();
-      const wrapper = getWrapper({ onClick, values, startDate, endDate });
-      const expectedValue = wrapper.state().valueCache['5'].value;
+      const wrapper = getWrapper({ ...props, onClick });
 
       const rect = wrapper.find('rect').at(0);
       rect.simulate('click');
 
       expect(onClick).toHaveBeenCalledWith(expectedValue);
+    });
+
+    it('calls props.onMouseOver with the correct value', () => {
+      const onMouseOver = jest.fn();
+      const wrapper = getWrapper({ ...props, onMouseOver });
+      const fakeEvent = { preventDefault: jest.fn() };
+
+      const rect = wrapper.find('rect').at(0);
+      rect.simulate('mouseOver', fakeEvent);
+
+      expect(onMouseOver).toHaveBeenCalledWith(fakeEvent, expectedValue);
+    });
+
+    it('calls props.onMouseLeave with the correct value', () => {
+      const onMouseLeave = jest.fn();
+      const wrapper = getWrapper({ ...props, onMouseLeave });
+      const fakeEvent = { preventDefault: jest.fn() };
+
+      const rect = wrapper.find('rect').at(0);
+      rect.simulate('mouseLeave', fakeEvent);
+
+      expect(onMouseLeave).toHaveBeenCalledWith(fakeEvent, expectedValue);
     });
   });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -7,6 +7,15 @@ import { dateNDaysAgo, shiftDate } from '../src/helpers';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+const getWrapper = (overrideProps, renderMethod = 'shallow') => {
+  const defaultProps = {
+    values: [],
+  };
+  return Enzyme[renderMethod](
+    <CalendarHeatmap {...defaultProps} {...overrideProps} />
+  );
+};
+
 describe('CalendarHeatmap', () => {
   const values = [
     { date: new Date('2017-06-01') },
@@ -229,6 +238,23 @@ describe('CalendarHeatmap props', () => {
       );
 
       expect(wrapper.find('[data-tooltip="Count: 1"]')).toHaveLength(1);
+    });
+  });
+
+  describe('event handlers', () => {
+    it('calls props.onClick', () => {
+      const count = 999;
+      const startDate = '2018-06-01';
+      const endDate = '2018-06-03';
+      const values = [ { date: '2018-06-02', count } ];
+      const onClick = jest.fn();
+      const wrapper = getWrapper({ onClick, values, startDate, endDate });
+      const expectedValue = wrapper.state().valueCache['5'].value;
+
+      const rect = wrapper.find('rect').at(0);
+      rect.simulate('click');
+
+      expect(onClick).toHaveBeenCalledWith(expectedValue);
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,7 +678,7 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
-babel-plugin-syntax-object-rest-spread@^6.13.0:
+babel-plugin-syntax-object-rest-spread@^6.13.0, babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
@@ -876,6 +876,13 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
   dependencies:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
+
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"


### PR DESCRIPTION
These were the only major missing points from the coverage report -- I'd like to start merging some of the outstanding PRs and would feel better about it if these were covered first. Once this is merged, the only uncovered line is the deprecation warning for `props.numDays`

before:

![image](https://user-images.githubusercontent.com/5827130/46807311-9dd9eb80-cd37-11e8-9e75-8c95af516ab3.png)
